### PR TITLE
Call packageActivationCompleted only once at the end

### DIFF
--- a/lib/action.js
+++ b/lib/action.js
@@ -12,6 +12,7 @@ const packageActivated = Reflux.createAction({
    *
    * @param {Package} pkg - The activated package.
    */
+  sync: true,
   preEmit: function(pkg) {
     debug(`Package ${pkg.metadata.name} activated.`);
   }
@@ -24,6 +25,7 @@ const packageActivationCompleted = Reflux.createAction({
   /**
    * Log the action.
    */
+  sync: true,
   preEmit: function() {
     debug('Package activation completed.');
   }
@@ -38,6 +40,7 @@ const packageRead = Reflux.createAction({
    *
    * @param {Package} pkg - The read package.
    */
+  sync: true,
   preEmit: function(pkg) {
     debug(`Package ${pkg.metadata.name} read.`);
   }
@@ -52,6 +55,7 @@ const packageScanFailed = Reflux.createAction({
    *
    * @param {Error} error - The error.
    */
+  sync: true,
   preEmit: function(error) {
     debug(`Package director scan failed: ${error.message}.`);
   }

--- a/lib/package-manager.js
+++ b/lib/package-manager.js
@@ -44,11 +44,11 @@ class PackageManager {
    * @returns {PackageManager} this instance.
    */
   activate() {
-    Action.packageRead.listen((pkg) => {
+    this.unsubscribePackageRead = Action.packageRead.listen((pkg) => {
       pkg.activate();
       this._completeActivation();
     });
-    Action.packageScanFailed.listen(() => {
+    this.unsubscribePackageScanFailed = Action.packageScanFailed.listen(() => {
       this._completeActivation();
     });
     this._read();
@@ -62,6 +62,9 @@ class PackageManager {
     if (this._isReadingComplete()) {
       this._resetExpectedPackageCount();
       Action.packageActivationCompleted();
+      // activation complete, unsubscribe from listeners
+      this.unsubscribePackageRead();
+      this.unsubscribePackageScanFailed();
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "mongodb-js-fmt": "^0.0.3",
     "mongodb-js-precommit": "^0.2.9",
     "pre-commit": "^1.1.2",
-    "react": "^0.14.8"
+    "react": "^0.14.8",
+    "sinon": "^1.17.6"
   }
 }

--- a/test/package-manager.test.js
+++ b/test/package-manager.test.js
@@ -2,20 +2,35 @@
 
 const path = require('path');
 const expect = require('chai').expect;
+const sinon = require('sinon');
 const Action = require('../lib/action');
 const PackageManager = require('../lib/package-manager');
 
 describe('PackageManager', function() {
   describe('#activate', function() {
     var packagesPath = path.join(__dirname, 'packages');
-    var manager = new PackageManager(packagesPath);
+    var manager;
+    beforeEach(function() {
+      manager = new PackageManager(packagesPath);
+    });
 
     it('activates all the packages', function(done) {
       var unsubscribe = Action.packageActivationCompleted.listen(function() {
-        expect(manager.packages).to.have.length(1);
+        expect(manager.packages).to.have.length(2);
         unsubscribe();
         done();
       });
+      manager.activate();
+    });
+
+    it('only calls Action.packageActivationCompleted once', function(done) {
+      const spy = sinon.spy();
+      var unsubscribe = Action.packageActivationCompleted.listen(spy);
+      setTimeout(function() {
+        expect(spy.callCount).to.be.equal(1);
+        unsubscribe();
+        done();
+      }, 10);
       manager.activate();
     });
   });

--- a/test/packages/example2/index.js
+++ b/test/packages/example2/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+  activate: function() {
+    return 'test';
+  }
+};

--- a/test/packages/example2/package.json
+++ b/test/packages/example2/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "test-package-2",
+  "version": "0.0.1",
+  "main": "./index",
+  "description": "Test package 2"
+}


### PR DESCRIPTION
The reflux actions used here were asynchronous by default, and their execution was deferred until after all packages were loaded. Inside `_completeActivation()` the condition `this._isReadingComplete()` was therefore always **true**, so the `packageActivationCompleted()` triggered once for each package loaded. Making the actions synchronous fixes this problem. 

Also, after loading is complete, the listeners need to be unregistered again. Otherwise there are issues when multiple managers are being used at once.

Tests included.
